### PR TITLE
Add selector for deployment to support v1 deployment

### DIFF
--- a/kubernetes-pipeline/templates/jenkins/jenkins-deployment.yaml
+++ b/kubernetes-pipeline/templates/jenkins/jenkins-deployment.yaml
@@ -21,11 +21,13 @@ metadata:
 spec:
   strategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: jenkins
   template:
     metadata:
       labels:
         app: jenkins
-        tier: jenkins
     spec:
       serviceAccountName: jenkins
       initContainers:


### PR DESCRIPTION
## Purpose
Deployment spec for API version v1 requires the field selector. Adding the selector field and remove the label tier.