### PR TITLE
Remove kubectl and dig tools from image

### DIFF
--- a/docker-images/jenkins/Dockerfile
+++ b/docker-images/jenkins/Dockerfile
@@ -19,44 +19,34 @@ USER root
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 
-# Installing Docker
+# Install Docker
 RUN apt-get update && apt-get install software-properties-common apt-transport-https ca-certificates -y; \
 curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -;\
 add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/debian  $(lsb_release -cs) stable";\
 apt-get update && apt-get install docker-ce -y
 
-# Installing kubectl from Docker
-RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -;\
-touch /etc/apt/sources.list.d/kubernetes.list;\
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list;\
-apt-get update && apt-get install -y kubectl
-
-# Installing utils for reverese DNS lookup
-RUN apt-get install knot-dnsutils -y
-RUN kdig
-# Installing maven
+# Install maven
 RUN apt-get install maven -y
-RUN mvn -v
 
-# Install helm
-RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > get_helm.sh
-RUN chmod 700 get_helm.sh
-RUN ./get_helm.sh
+# Install Helm
+RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > get_helm.sh && \
+chmod 700 get_helm.sh && \
+./get_helm.sh && \
+rm get_helm.sh
 
-RUN wget https://www-us.apache.org/dist//jmeter/binaries/apache-jmeter-5.1.tgz
-RUN tar -C /usr/local -xzf apache-jmeter-5.1.tgz
-ENV PATH="/usr/local/apache-jmeter-5.1/bin:${PATH}"
+# Install Jmeter
+RUN wget https://www-us.apache.org/dist//jmeter/binaries/apache-jmeter-5.1.tgz && \
+tar -C /usr/local -xzf apache-jmeter-5.1.tgz && \
+rm apache-jmeter-5.1.tgz
 
 # Grant jenkins user group access to /var/run/docker.sock
-RUN addgroup --gid 1001 dsock
-RUN gpasswd -a jenkins dsock
+RUN addgroup --gid 1001 dsock && \
+gpasswd -a jenkins dsock && \
+usermod -aG sudo jenkins
 
-RUN usermod -aG sudo jenkins
-
+# Install microgateway toolkit
 COPY wso2am-micro-gw-toolkit-3.0.1.zip /wso2am-micro-gw-toolkit-3.0.1.zip
-RUN unzip /wso2am-micro-gw-toolkit-3.0.1.zip
+RUN unzip /wso2am-micro-gw-toolkit-3.0.1.zip && \
+rm /wso2am-micro-gw-toolkit-3.0.1.zip
 
-RUN ls /wso2am-micro-gw-toolkit-3.0.1/bin
-ENV PATH="${PATH}:/wso2am-micro-gw-toolkit-3.0.1/bin"
-
-# USER JENKINS
+ENV PATH="${PATH}:/wso2am-micro-gw-toolkit-3.0.1/bin:/usr/local/apache-jmeter-5.1/bin"


### PR DESCRIPTION
## Purpose
- Remove kubectl since deployment is done by spinnaker instead of from the Jenkins container.
- Remove dig since it is no longer necessary to use an internal registry.