### PR TITLE
Remove unused jenkins shared library

### DIFF
--- a/kubernetes-pipeline/templates/jenkins/jenkins-casc-conf.yaml
+++ b/kubernetes-pipeline/templates/jenkins/jenkins-casc-conf.yaml
@@ -18,16 +18,6 @@ metadata:
   name: jenkins-casc-conf
 data:
   global-config.yaml: |-
-    unclassified:
-      globalLibraries:
-        libraries:
-          - name: "wso2-jenkins-shared-lib"
-            defaultVersion: master
-            retriever:
-              modernSCM:
-                scm:
-                  git:
-                    remote: "https://github.com/Aaquiff/jenkins-shared-lib"
     credentials:
       system:
         domainCredentials:


### PR DESCRIPTION
## Purpose
- Removed shared lib `https://github.com/Aaquiff/jenkins-shared-lib` from `jenkins-casc-conf.yaml`.