### PR TITLE
Adding  support for TLS in ingress resources in Helm chart

### DIFF
--- a/kubernetes-pipeline/templates/NOTES.txt
+++ b/kubernetes-pipeline/templates/NOTES.txt
@@ -6,19 +6,19 @@ Please follow these steps to access the pipeline tools in the environment.
 
   kubectl get ing -n {{ .Release.Namespace }}
 
-    NAME                                  HOSTS           ADDRESS           PORTS       AGE
-    <RELEASE_NAME>-grafana                grafana         <EXTERNAL_IP>     80          20m
-    <RELEASE_NAME>-kibana                 kibana          <EXTERNAL_IP>     80          20m
-    <RELEASE_NAME>-spinnaker-deck         spinnaker       <EXTERNAL_IP>     80, 443     20m
-    <RELEASE_NAME>-spinnaker-gate         gate.spinnaker  <EXTERNAL_IP>     80, 443     20m
-    jenkins-ingress                       jenkins         <EXTERNAL_IP>     80, 443     20m
+    NAME                                  HOSTS                       ADDRESS           PORTS       AGE
+    <RELEASE_NAME>-grafana                grafana.example.com         <EXTERNAL_IP>     80          20m
+    <RELEASE_NAME>-kibana                 kibana.example.com          <EXTERNAL_IP>     80          20m
+    <RELEASE_NAME>-spinnaker-deck         spinnaker.example.com       <EXTERNAL_IP>     80, 443     20m
+    <RELEASE_NAME>-spinnaker-gate         gate.spinnaker.example.com  <EXTERNAL_IP>     80, 443     20m
+    jenkins-ingress                       jenkins.example.com         <EXTERNAL_IP>     80, 443     20m
 
 2. Add the above host as an entry in /etc/hosts file as follows:
 
-    <EXTERNAL-IP> grafana kibana spinnaker gate.spinnaker jenkins
+    <EXTERNAL-IP> grafana.example.com kibana.example.com spinnaker.example.com gate.spinnaker.example.com jenkins.example.com
 
 3. Navigate to the following URLs on any web browser to access the pipeline tools
-    - https://jenkins
-    - https://spinnaker
-    - https://kibana
-    - https://grafana
+    - https://jenkins.example.com
+    - https://spinnaker.example.com
+    - https://kibana.example.com
+    - https://grafana.example.com

--- a/kubernetes-pipeline/templates/NOTES.txt
+++ b/kubernetes-pipeline/templates/NOTES.txt
@@ -1,3 +1,9 @@
+{{ $jenkins_host := .Values.jenkins.ingress.host }}
+{{ $spinnaker_host := .Values.spinnaker.ingress.host }}
+{{ $spinnaker_gate_host := .Values.spinnaker.ingressGate.host }}
+{{ $grafana_host := index (index .Values "prometheus-operator" "grafana" "ingress" "hosts") 0 }}
+{{ $kibana_host := index .Values.kibana.ingress.hosts 0 }}\
+
 Thank you for installing WSO2 Kubernetes Pipeline.
 
 Please follow these steps to access the pipeline tools in the environment.
@@ -6,19 +12,20 @@ Please follow these steps to access the pipeline tools in the environment.
 
   kubectl get ing -n {{ .Release.Namespace }}
 
-    NAME                                  HOSTS                       ADDRESS           PORTS       AGE
-    <RELEASE_NAME>-grafana                grafana.example.com         <EXTERNAL_IP>     80          20m
-    <RELEASE_NAME>-kibana                 kibana.example.com          <EXTERNAL_IP>     80          20m
-    <RELEASE_NAME>-spinnaker-deck         spinnaker.example.com       <EXTERNAL_IP>     80, 443     20m
-    <RELEASE_NAME>-spinnaker-gate         gate.spinnaker.example.com  <EXTERNAL_IP>     80, 443     20m
-    jenkins-ingress                       jenkins.example.com         <EXTERNAL_IP>     80, 443     20m
+    NAME                                  HOSTS                             ADDRESS           PORTS       AGE
+    jenkins-ingress                       {{ $jenkins_host }}               <EXTERNAL_IP>     80, 443     20m
+    <RELEASE_NAME>-spinnaker-deck         {{ $spinnaker_host }}             <EXTERNAL_IP>     80, 443     20m
+    <RELEASE_NAME>-spinnaker-gate         {{ $spinnaker_gate_host }}        <EXTERNAL_IP>     80, 443     20m
+    <RELEASE_NAME>-grafana                {{ $grafana_host }}               <EXTERNAL_IP>     80, 443     20m
+    <RELEASE_NAME>-kibana                 {{ $kibana_host }}                <EXTERNAL_IP>     80, 443     20m
 
-2. Add the above host as an entry in /etc/hosts file as follows:
+2. Add the above hosts as an entry in /etc/hosts file as follows:
 
-    <EXTERNAL-IP> grafana.example.com kibana.example.com spinnaker.example.com gate.spinnaker.example.com jenkins.example.com
+    <EXTERNAL-IP> {{ $jenkins_host }} {{ $spinnaker_host }} {{ $spinnaker_gate_host }} {{ $grafana_host }} {{ $kibana_host }}
 
 3. Navigate to the following URLs on any web browser to access the pipeline tools
-    - https://jenkins.example.com
-    - https://spinnaker.example.com
-    - https://kibana.example.com
-    - https://grafana.example.com
+    - https://{{ $jenkins_host }}
+    - https://{{ $spinnaker_host }}
+    - https://{{ $spinnaker_gate_host }}
+    - https://{{ $grafana_host }}
+    - https://{{ $kibana_host }}

--- a/kubernetes-pipeline/templates/jenkins/service.yaml
+++ b/kubernetes-pipeline/templates/jenkins/service.yaml
@@ -27,21 +27,26 @@ spec:
 
 ---
 
+{{- if .Values.jenkins.ingress.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: jenkins-ingress
+{{- if .Values.jenkins.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+{{ toYaml .Values.jenkins.ingress.annotations | indent 4 }}
+{{- end }}
+  name: jenkins-ingress
 spec:
-  tls:
-  - hosts:
-    - {{ .Values.jenkins.ingress.host }}
   rules:
-  - host: {{ .Values.jenkins.ingress.host }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: jenkins-service
-          servicePort: 8080
+    - host: {{ .Values.jenkins.ingress.host | quote }}
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: jenkins-service
+            servicePort: 8080
+  {{- if .Values.jenkins.ingress.tls }}
+  tls:
+{{ toYaml .Values.jenkins.ingress.tls | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/kubernetes-pipeline/values.yaml
+++ b/kubernetes-pipeline/values.yaml
@@ -21,7 +21,16 @@ jenkins:
   username: admin
   password: jenkins_admin
   ingress:
+    enabled: true
     host: jenkins.example.com
+    annotations:
+      ingress.kubernetes.io/ssl-redirect: 'true'
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+#    tls:
+#      - secretName: -tls
+#        hosts:
+#          - example.com
 
 registry:
   server: 'https://index.docker.io/v1/'
@@ -46,7 +55,7 @@ spinnaker:
         enable_ci.sh: |-
           echo "Configuring jenkins master"
           USERNAME="admin"
-          PASSWORD="admin"
+          PASSWORD="jenkins_admin"
           $HAL_COMMAND config ci jenkins enable
           echo $PASSWORD | $HAL_COMMAND config ci jenkins master edit master --address http://jenkins-service.{{ .Release.Namespace }}.svc.cluster.local:8080 --username $USERNAME --password || echo $PASSWORD | $HAL_COMMAND config ci jenkins master add master --address http://jenkins-service.{{ .Release.Namespace }}.svc.cluster.local:8080 --username $USERNAME --password
           $HAL_COMMAND config features edit --pipeline-templates true
@@ -57,10 +66,10 @@ spinnaker:
       ingress.kubernetes.io/ssl-redirect: 'true'
       kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: "true"
-    tls:
-      - secretName: '-tls'
-        hosts:
-          - example.com
+#    tls:
+#      - secretName: -tls
+#        hosts:
+#          - example.com
   ingressGate:
     enabled: true
     host: gate.spinnaker.example.com
@@ -68,10 +77,10 @@ spinnaker:
       ingress.kubernetes.io/ssl-redirect: 'true'
       kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: "true"
-    tls:
-     - secretName: -tls
-       hosts:
-         - example.com
+#    tls:
+#     - secretName: -tls
+#       hosts:
+#         - example.com
 
 kibana:
   nameOverride: "kibana"
@@ -80,9 +89,10 @@ kibana:
     enabled: true
     hosts:
       - kibana.example.com
-    tls:
-      - hosts:
-          - example.com
+#    tls:
+#      - hosts:
+#          - example.com
+#        secretName: -tls
           
 elasticsearch:
   minimumMasterNodes: 1
@@ -121,7 +131,11 @@ prometheus-operator:
       annotations: 
         kubernetes.io/ingress.class: nginx
       hosts:
-        - grafana.example.com
+      - grafana.example.com
+#      tls:
+#        - hosts:
+#            - example.com
+#          secretName: -tls
 
 nodeExporter:
   enabled: false

--- a/kubernetes-pipeline/values.yaml
+++ b/kubernetes-pipeline/values.yaml
@@ -19,7 +19,7 @@ wso2Password: ""
 # Admin credentials of jenkins instance to be created
 jenkins:
   username: admin
-  password: admin
+  password: jenkins_admin
   ingress:
     host: jenkins.example.com
 

--- a/samples/values-ei-pattern-1.yaml
+++ b/samples/values-ei-pattern-1.yaml
@@ -23,7 +23,7 @@ registry:
   username: &reg_username <REGISTRY_USERNAME>
   password: &reg_password <REGISTRY_PASSWORD>
   email: &reg_email <REGISTRY_EMAIL>
-  address: &reg_email index.docker.io
+  address: &reg_address index.docker.io
   # Add each repositories that would be used in the deployment
   repositories:
     &reg_repos

--- a/samples/values-is-pattern-1.yaml
+++ b/samples/values-is-pattern-1.yaml
@@ -23,7 +23,7 @@ registry:
   username: &reg_username <REGISTRY_USERNAME>
   password: &reg_password <REGISTRY_PASSWORD>
   email: &reg_email <REGISTRY_EMAIL>
-  address: &reg_email index.docker.io
+  address: &reg_address index.docker.io
   # Add each repositories that would be used in the deployment
   repositories:
     &reg_repos


### PR DESCRIPTION
## Purpose
Purpose of the chart is to enable configuring TLS certificates for public ingress endpoints.
In addition to this, the following fixes are included/
- Change the default password of Jenkins from `jenkins` to `jenkins-admin`
- Fix incorrect yaml reference for registry address in samples