### PR TITLE
Automatically roll deployment when JCasC configmap changes

### DIFF
--- a/kubernetes-pipeline/templates/jenkins/jenkins-deployment.yaml
+++ b/kubernetes-pipeline/templates/jenkins/jenkins-deployment.yaml
@@ -28,6 +28,8 @@ spec:
     metadata:
       labels:
         app: jenkins
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/jenkins/jenkins-casc-conf.yaml") . | sha256sum }}
     spec:
       serviceAccountName: jenkins
       initContainers:


### PR DESCRIPTION
## Purpose
When Jenkins configuration as code configmap is changed, Jenkins pod should be restarted for the configuration changes to be reflected. This could be done using **AUTOMATICALLY ROLL DEPLOYMENTS** [1]

https://helm.sh/docs/howto/charts_tips_and_tricks/