### PR TITLE
Change structure of Jenkins image name and tag values

### DIFF
--- a/kubernetes-pipeline/templates/jenkins/jenkins-deployment.yaml
+++ b/kubernetes-pipeline/templates/jenkins/jenkins-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: helm-conf
           mountPath: "/root/.helm"
       containers:
-      - image: {{ .Values.image }}
+      - image: {{ .Values.jenkins.image.repository }}:{{ .Values.jenkins.image.tag }}
         name: jenkins
         env:
         - name: JAVA_OPTS

--- a/kubernetes-pipeline/values.yaml
+++ b/kubernetes-pipeline/values.yaml
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-image: 'wso2/kubernetes-pipeline-jenkins:latest'
 wso2Username: ""
 wso2Password: ""
 
-# Admin credentials of jenkins instance to be created
+
 jenkins:
+  image:
+    repository: "wso2/kubernetes-pipeline-jenkins"
+    tag: "latest"
+  # Admin credentials of jenkins instance to be created
   username: admin
   password: jenkins_admin
   ingress:


### PR DESCRIPTION
## Purpose
The current value for Jenkins image should be nested under the Jenkins tag. The tag should also be separated from the repository name to be consistent with other Helm charts. 