### PR TITLE
[1.1.0] Use Helm Version 3 as the Rendering Engine in Spinnaker

### DIFF
--- a/docker-images/jenkins/Dockerfile
+++ b/docker-images/jenkins/Dockerfile
@@ -16,7 +16,7 @@ FROM jenkins/jenkins:2.235.2
 
 USER root
 
-ARG HELM_VERSION=v2.16.7
+ARG HELM_VERSION=v3.2.4
 ARG JMETER_VERSION=5.1
 ARG MGW_TOOLKIT_VERSION=3.0.1
 ARG DOCKER_VERSION="18.06.3~ce~3-0~debian"
@@ -48,10 +48,10 @@ RUN \
 
 # Install Helm
 RUN \
-    curl https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get > get_helm.sh \
-    && chmod 700 get_helm.sh \
-    && ./get_helm.sh --version ${HELM_VERSION} \
-    && rm get_helm.sh
+    wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
+    && tar -zxvf helm-${HELM_VERSION}-linux-amd64.tar.gz \
+    && mv linux-amd64/helm /usr/local/bin/helm \
+    && rm -r linux-amd64
 
 # Install JMeter
 RUN \

--- a/kubernetes-pipeline/templates/jenkins/jenkins-casc-conf.yaml
+++ b/kubernetes-pipeline/templates/jenkins/jenkins-casc-conf.yaml
@@ -268,6 +268,7 @@ data:
               helm package {{ .chart.name }} -u
               {{- else }}
               helm repo add wso2 https://helm.wso2.com
+              helm repo update
               helm fetch wso2/{{ .chart.name }} --version {{ .chart.version }}
               {{- end }}
 

--- a/kubernetes-pipeline/templates/jenkins/jenkins-casc-conf.yaml
+++ b/kubernetes-pipeline/templates/jenkins/jenkins-casc-conf.yaml
@@ -253,37 +253,6 @@ data:
             steps {
               shell(
               """
-              removeTests() {
-                  for f in *
-                  do
-                      # Extract chart and get name
-                      if [ -d \$f ]; then 
-                          echo "\$f is a directory"
-                          CHART_NAME=\$f
-                      else
-                          echo "\$f is not a directory"
-                          tar -zxf \$f
-                          CHART_NAME=`tar -tzf \$f | head -1 | cut -f1 -d"/"`
-                          rm -r \$f
-                      fi
-
-                      # Remove tests folder
-                      if [ -d \$CHART_NAME/templates/tests ]; then
-                          echo "Removing \$CHART_NAME/templates/tests"
-                          rm -r \$CHART_NAME/templates/tests
-                      fi
-
-                      if [ -d \$CHART_NAME/charts ]; then
-                          echo "Dependencies for chart \$CHART_NAME"
-                          cd \$CHART_NAME/charts && 
-                          removeTests 
-                          cd ../../
-                      else
-                          echo "No dependencies for chart \$CHART_NAME"
-                      fi
-                  done;
-              }
-
               cat {{ .chart.name }}/values-dev.yaml | base64 >test
               VALUES_DEV_CONTENT=`tr -d '\\n' < test`
 
@@ -298,17 +267,9 @@ data:
               {{- if .chart.customChart }}
               helm package {{ .chart.name }} -u
               {{- else }}
-              helm repo update
+              helm repo add wso2 https://helm.wso2.com
               helm fetch wso2/{{ .chart.name }} --version {{ .chart.version }}
               {{- end }}
-
-              tar -zxf {{ .chart.name }}-*.tgz
-              if [ -d {{ .chart.name }}/charts ]; then
-              cd {{ .chart.name }}/charts
-              removeTests
-              cd ../../
-              fi
-              helm package {{ .chart.name }}
 
               CHART_NAME=`find {{ .chart.name }}-*.tgz`
               cat \$CHART_NAME | base64 > test
@@ -321,7 +282,6 @@ data:
               WEBHOOK_ENDPOINT=http://spin-gate.{{ $namespace }}.svc.cluster.local:8084/webhooks/webhook/chart
               while [ "\$(curl -s -o /dev/null -w ''%{http_code}'' -X POST --header "Content-Type: application/json" --request POST --data @data.json \$WEBHOOK_ENDPOINT)" != "200" ]; do sleep 60; done
               """)
-
             }
           }
       {{- end }}

--- a/kubernetes-pipeline/templates/spinnaker/spinnaker-pipeline-creator.yaml
+++ b/kubernetes-pipeline/templates/spinnaker/spinnaker-pipeline-creator.yaml
@@ -230,7 +230,7 @@ data:
                 },
                 "refId": "1",
                 "requisiteStageRefIds": [],
-                "templateRenderer": "HELM2",
+                "templateRenderer": "HELM3",
                 "type": "bakeManifest"
             },
             {
@@ -283,7 +283,7 @@ data:
                 },
                 "refId": "3",
                 "requisiteStageRefIds": [],
-                "templateRenderer": "HELM2",
+                "templateRenderer": "HELM3",
                 "type": "bakeManifest"
             },
             {
@@ -336,7 +336,7 @@ data:
                 },
                 "refId": "8",
                 "requisiteStageRefIds": [],
-                "templateRenderer": "HELM2",
+                "templateRenderer": "HELM3",
                 "type": "bakeManifest"
             }
         ],


### PR DESCRIPTION
## Purpose
> This PR sets Spinnaker to use Helm version 3 as the rendering engine. Thus, this fixes https://github.com/wso2/kubernetes-pipeline/issues/83.

## Goals
> Use Helm Version 3 as the Rendering Engine in Spinnaker

## Test environment
> Helm version: 3.1.2
> GKE based Kubernetes Server version: 1.14+, Git Version: `v1.14.10-gke.27`
> WSO2 product images available at DockerHub were used