### PR TITLE
[1.1.0] Upgrade Logging Component Tools

### DIFF
--- a/kubernetes-pipeline/requirements.yaml
+++ b/kubernetes-pipeline/requirements.yaml
@@ -7,10 +7,10 @@ dependencies:
   version: 8.3.0
   repository: https://kubernetes-charts.storage.googleapis.com
 - name: kibana
-  version: 7.3.0
+  version: 7.8.1
   repository: https://helm.elastic.co
 - name: elasticsearch
-  version: 7.3.0
+  version: 7.8.1
   repository: https://helm.elastic.co
 - name: prometheus-blackbox-exporter
   version: 1.5.1

--- a/kubernetes-pipeline/values.yaml
+++ b/kubernetes-pipeline/values.yaml
@@ -116,7 +116,7 @@ kibana:
 elasticsearch:
   minimumMasterNodes: 1
   replicas: 1
-  imageTag: 7.3.0
+  imageTag: 7.8.1
   clusterName: wso2-elasticsearch
   persistence:
     enabled: false


### PR DESCRIPTION
## Purpose
> This PR addresses $subject for Kibana and Elasticsearch Helm charts. This fixes the linked issues.

## Goals
> Upgrade Logging Component Tools

## Test environment
> Helm version: `3.1.2`
> GKE based Kubernetes Server version: `1.15`+, Git Version: `v1.15.12-gke.2`
> WSO2 product images available at DockerHub and WSO2 Private Docker Registry were used