### PR TITLE
[1.1.0] Add support for MI remote unit test server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@ All notable changes to this project per each release will be documented in this 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v1.1.0] - 2020-09-22
+
+### Environments
+- Successful evaluation of Kubernetes pipeline Helm chart in Google Kubernetes Engine (GKE) versions: `1.14.10-gke.50`, `v1.15.12-gke.2`
+
+### Added
+- Introduce Micro Integrator pipeline (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/66))
+- Support For Test Scripts Stored In GitHub Private Repositories (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/78)) 
+- Support For Pipeline Credential Updates (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/79)) 
+- Micro integrator endpoint requirement at the docker build stage (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/95))
+- Set Option to Define the Frequency of Registry Image Updates (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/76))
+- Add Microgateway Toolkit to Jenkins Docker Image using a Downloadable Link (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/102))
+
+### Changed
+- Upgrade Base Jenkins Docker Image And Plugins Used (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/72))
+- Change Jenkins deployment strategy to Recreate (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/98))
+- Upgrade Stable Spinnaker Helm Chart Version (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/85))
+- Use Helm Version 3 as the Rendering Engine in Spinnaker (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/83))
+- Upgrade Elasticsearch Helm Chart Version (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/90))
+- Upgrade Kibana Helm Chart Version (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/89))
+- Upgrade Prometheus operator and Spinnaker charts (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/96))
+- Upgrade Microgateway Toolkit Version to Latest (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/101))
+- Dockerfile for Jenkins can be improved (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/7)) 
+
+### Fixed
+- Prometheus is not starting up (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/65)) 
+- Helm chart build fails in Jenkins when chart contains no dependency (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/59))
+- Define versions for the tools in the Jenkins image (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/68))
+- Set Explicit Kubernetes Namespace Override By Spinnaker (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/77))
+- Add artifact constraint for chart trigger (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/97))
+- Fix the incorrect Docker repository in the sample MI value YAML (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/93))
+- Micro integrator endpoint requirement at the docker build stage (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/95))
+- Evaluate Usage of Latest Helm Version 2 in Jenkins (refer to [issue](https://github.com/wso2/kubernetes-pipeline/issues/82))
+
+
 ## [v1.0.0] - 2019-12-17
 
 - Add advanced documentation topics
@@ -44,3 +79,6 @@ For detailed information on the tasks carried out during this release, please se
 [v0.1.2]: https://github.com/wso2/kubernetes-pipeline/compare/v0.1.1...v0.1.2
 
 [v1.0.0]: https://github.com/wso2/kubernetes-pipeline/compare/v0.1.2...v1.0.0
+
+[v1.1.0]: https://github.com/wso2/kubernetes-pipeline/compare/v1.0.0...v1.1.0
+

--- a/kubernetes-pipeline/samples/values-mi.yaml
+++ b/kubernetes-pipeline/samples/values-mi.yaml
@@ -49,7 +49,7 @@ applications:
     chart:
       customChart: false
       name: micro-integrator
-      version: 1.2.0-1
+      version: 1.2.0-3
       repo: 'https://github.com/wso2-incubator/cicd-sample-chart-mi'
     images:
       - organization: *reg_username
@@ -58,3 +58,8 @@ applications:
         wso2microIntegrator:
           baseImage: 'wso2/wso2mi:1.2.0'
           gitRepository: 'https://github.com/wso2-incubator/cicd-sample-docker-mi'
+          remoteSynapseTestServer:
+            enabled: false
+            hostname: ''
+            port: 9008
+

--- a/kubernetes-pipeline/templates/jenkins/jenkins-casc-conf.yaml
+++ b/kubernetes-pipeline/templates/jenkins/jenkins-casc-conf.yaml
@@ -101,7 +101,25 @@ data:
                 TAG=`git rev-parse --short HEAD`
 
                 {{- if $image.wso2microIntegrator }}
-                mvn clean install -Ddockerfile.base.image=\$TAGGED_BASE_IMAGE -Ddockerfile.tag=\$TIMESTAMP-\$TAG -Ddockerfile.repository=\$REGISTRY_NAME/\$REPOSITORY -Ddockerfile.username=\$REGISTRY_USERNAME -Ddockerfile.password=\$REGISTRY_PASSWORD -Ddockerfile.build.pullNewerImage=false
+                {{- if $image.wso2microIntegrator.remoteSynapseTestServer.enabled }}
+                mvn clean install -Ddockerfile.base.image=\$TAGGED_BASE_IMAGE \
+                -Ddockerfile.tag=\$TIMESTAMP-\$TAG \
+                -Ddockerfile.repository=\$REGISTRY_NAME/\$REPOSITORY \
+                -Ddockerfile.username=\$REGISTRY_USERNAME \
+                -Ddockerfile.password=\$REGISTRY_PASSWORD \
+                -Ddockerfile.build.pullNewerImage=false \
+                -DtestServerType=remote \
+                -DtestServerHost={{ $image.wso2microIntegrator.remoteSynapseTestServer.hostname }} \
+                -DtestServerPort={{ $image.wso2microIntegrator.remoteSynapseTestServer.port }}
+                {{- else }}
+                mvn clean install -Ddockerfile.base.image=\$TAGGED_BASE_IMAGE \
+                -Ddockerfile.tag=\$TIMESTAMP-\$TAG \
+                -Ddockerfile.repository=\$REGISTRY_NAME/\$REPOSITORY \
+                -Ddockerfile.username=\$REGISTRY_USERNAME \
+                -Ddockerfile.password=\$REGISTRY_PASSWORD \
+                -Ddockerfile.build.pullNewerImage=false \
+                -Dmaven.test.skip=true
+                {{- end }}
                 {{- else }}
                 sed -i \"s|<BASE>|\$TAGGED_BASE_IMAGE|\" Dockerfile
                 docker build -t \$REGISTRY_NAME/\$REPOSITORY:\$TIMESTAMP-\$TAG .
@@ -164,7 +182,25 @@ data:
 
                 TAG=`git rev-parse --short HEAD`
                 {{- if $image.wso2microIntegrator }}
-                mvn clean install -Ddockerfile.base.image=\$TAGGED_BASE_IMAGE -Ddockerfile.tag=\$TIMESTAMP-\$TAG -Ddockerfile.repository=\$REGISTRY_NAME/\$REPOSITORY -Ddockerfile.username=\$REGISTRY_USERNAME -Ddockerfile.password=\$REGISTRY_PASSWORD -Ddockerfile.build.pullNewerImage=false
+               {{- if $image.wso2microIntegrator.remoteSynapseTestServer.enabled }}
+                mvn clean install -Ddockerfile.base.image=\$TAGGED_BASE_IMAGE \
+                -Ddockerfile.tag=\$TIMESTAMP-\$TAG \
+                -Ddockerfile.repository=\$REGISTRY_NAME/\$REPOSITORY \
+                -Ddockerfile.username=\$REGISTRY_USERNAME \
+                -Ddockerfile.password=\$REGISTRY_PASSWORD \
+                -Ddockerfile.build.pullNewerImage=false \
+                -DtestServerType=remote \
+                -DtestServerHost={{ $image.wso2microIntegrator.remoteSynapseTestServer.hostname }} \
+                -DtestServerPort={{ $image.wso2microIntegrator.remoteSynapseTestServer.port }}
+               {{- else }}
+                mvn clean install -Ddockerfile.base.image=\$TAGGED_BASE_IMAGE \
+                -Ddockerfile.tag=\$TIMESTAMP-\$TAG \
+                -Ddockerfile.repository=\$REGISTRY_NAME/\$REPOSITORY \
+                -Ddockerfile.username=\$REGISTRY_USERNAME \
+                -Ddockerfile.password=\$REGISTRY_PASSWORD \
+                -Ddockerfile.build.pullNewerImage=false \
+                -Dmaven.test.skip=true
+               {{- end }}
                 {{- else }}
                 sed -i \"s|<BASE>|\$TAGGED_BASE_IMAGE|\" Dockerfile
                 docker build -t \$REGISTRY_NAME/\$REPOSITORY:\$TIMESTAMP-\$TAG .


### PR DESCRIPTION
## Purpose
> This PR enables support for MI remote unit test server at the build stage. This fixes #95. 
## Goals
> Add support for MI remote unit test server.

## Test environment
> Client Version: version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.5", GitCommit:"51dd616cdd25d6ee22c83a858773b607328a18ec", GitTreeState:"clean", BuildDate:"2019-01-16T18:24:45Z", GoVersion:"go1.10.7", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"14+", GitVersion:"v1.14.10-gke.50", GitCommit:"bc01f00cf59008a36aa47f67c37c36b9d66db718", GitTreeState:"clean", BuildDate:"2020-09-09T03:06:32Z", GoVersion:"go1.12.12b4", Compiler:"gc", Platform:"linux/amd64"}
